### PR TITLE
Fix for Windows Systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,9 +73,9 @@ module.exports.rules = {
             if (source !== expectedPath) {
               context.report({
                 node,
-                message: `Relative imports are not allowed. Use \`${expectedPath}\` instead of \`${source}\`.`,
+                message: `Relative imports are not allowed. Use \`${expectedPath.replace(/\\/g, "/")}\` instead of \`${source}\`.`,
                 fix: function (fixer) {
-                  return fixer.replaceText(node.source, `'${expectedPath}'`);
+                  return fixer.replaceText(node.source, `'${expectedPath.replace(/\\/g, "/")}'`);
                 },
               });
             }


### PR DESCRIPTION
One of the issues with eslint-plugin-absolute-imports is that it replaces the forward slashes in the path with backslashes on windows systems. This is a simple fix for that issue.